### PR TITLE
Migra guia Como organizar eventos usando infra da APyB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    		?=
+SPHINXOPTS    		?= -b dirhtml
 SPHINXBUILD   		?= sphinx-build
 SOURCEDIR     		= source
 BUILDDIR      		= build

--- a/source/guias/index.md
+++ b/source/guias/index.md
@@ -1,0 +1,11 @@
+---
+hide-toc: true
+---
+
+# Guias
+
+```{toctree}
+:maxdepth: 1
+
+como-organizar-eventos
+```

--- a/source/index.md
+++ b/source/index.md
@@ -2,12 +2,24 @@
 hide-toc: true
 ---
 
-# Boas vindas a documentação da APyB
+# Associação Python Brasil
+
+Boas vindas a wiki da Associação Python Brasil.
+
+**Para associados**
+- [Como organizar eventos usando a infraestrutura da APyB](/guias/como-organizar-eventos)
+- [Guia para organização da Python Brasil](https://manual.pythonbrasil.org.br)
+
+**Para direção e conselho**
+...
+
 
 ```{toctree}
-:caption: Eventos
+:maxdepth: 1
+:caption: Associados
 :hidden:
 
+guias/index
 ```
 
 ```{toctree}


### PR DESCRIPTION
Com o objetivo de fomentar a wiki da APyB (apyb.python.org.br), estou migrando o conteúdo do guia [Como organizar eventos usando a infraestrutura da APyB](https://docs.google.com/document/d/1j0UwPbZrN1E8W3zdclzyIxaFPgztjLAATSdsPAizFX0/edit#).

Não fiz nenhuma alteração ou revisão do documento, apenas trouxe o conteúdo formatado como o original.