### PR TITLE
Atualiza valor da anuidade

### DIFF
--- a/source/associados/associe-se.rst
+++ b/source/associados/associe-se.rst
@@ -19,13 +19,13 @@ Existem duas categorias de membros:
 Estudantes
 ^^^^
 
-- Anuidade: R$32,00
+- Anuidade: R$60,00
 - Direito a votar em eleições para cidade sede da Python Brasil
 
 Efetivo
 ^^^^
 
-- Anuidade: R$64,00
+- Anuidade: R$120,00
 - Direito a votar e ser votado para cargos da APyB
 - Direito a votar em propostas de alteração no estatuto
 - Direito a votar em eleições para cidade sede da Python Brasil


### PR DESCRIPTION
Conforme anunciado na Assembleia Extraordinária de 2026, a partir de 27/04/2026 os valores da anuidade dos associados serão:
- R$60 para membros estudantes
- R$120 para membros efetivos 