### PR TITLE
Atualiza endereço

### DIFF
--- a/source/associados/guias/como-organizar-eventos.md
+++ b/source/associados/guias/como-organizar-eventos.md
@@ -68,8 +68,8 @@ Ao solicitar movimentação financeira ou recebimento de recursos do exterior, t
 
 * - Endereço
   - Rua José Tovasi, 417
-    <br>Bairro Cruzeiro, Caxias do Sul, RS
-    <br>95.072-300
+    <br>Bairro Bela Vista, Caxias do Sul, RS
+    <br>95.072-342
 
 * - Banco
   - 001 Banco do Brasil


### PR DESCRIPTION
O CEP da rua José Tovazzi foi desmembrado em 2024.

Conforme o cartão do CNPJ da APyB, o bairro e o CEP foram atualizados na Receita Federal:

<img width="1010" height="1008" alt="telegram-cloud-photo-size-1-5105240841382464730-y" src="https://github.com/user-attachments/assets/276804f1-2654-4459-a0f9-7ddece3ccbf9" />
